### PR TITLE
replace deprecated set-output usage

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -24,4 +24,4 @@ runs:
       shell: bash
       run: |
         RESULT=$(${{ github.action_path }}/check.sh ${{ inputs.base-image }} ${{ inputs.derived-image }})
-        echo "::set-output name=differs::$RESULT"
+        echo "differs=$RESULT" >> $GITHUB_OUTPUT


### PR DESCRIPTION
See [here](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) for context.